### PR TITLE
Updated JGitWrapper to insert username in URL

### DIFF
--- a/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/git/JGitWrapper.java
+++ b/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/git/JGitWrapper.java
@@ -32,6 +32,8 @@ public class JGitWrapper {
     private final String localPath;
     private final String remotePath;
 
+    private final String branch;
+
     private final String commitAuthor;
     private final String commitEmail;
 
@@ -56,6 +58,10 @@ public class JGitWrapper {
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid remote git url");
         }
+
+        branch = preferences.getString("git_branch", "");
+        if (branch.isEmpty())
+            throw new IllegalArgumentException("Must specify a git branch");
 
         commitAuthor = preferences.getString("git_commit_author", "");
         commitEmail = preferences.getString("git_commit_email", "");
@@ -93,6 +99,7 @@ public class JGitWrapper {
         try {
             CloneCommand cloneCommand = Git.cloneRepository()
                     .setURI(remotePath)
+                    .setBranch(branch)
                     .setDirectory(localRepo)
                     .setBare(false);
             if (monitor != null)

--- a/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/git/JGitWrapper.java
+++ b/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/git/JGitWrapper.java
@@ -20,8 +20,10 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.merge.MergeStrategy;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.SshSessionFactory;
+import org.eclipse.jgit.transport.URIish;
 
 import java.io.File;
+import java.net.URISyntaxException;
 
 public class JGitWrapper {
 
@@ -41,9 +43,19 @@ public class JGitWrapper {
         if (TextUtils.isEmpty(localPath))
             throw new IllegalArgumentException("Must specify local git path");
 
-        remotePath = preferences.getString("git_url", "");
-        if (TextUtils.isEmpty(remotePath))
+        String url = preferences.getString("git_url", "");
+        if (TextUtils.isEmpty(url))
             throw new IllegalArgumentException("Must specify remote git url");
+        try {
+            URIish urIish = new URIish(url);
+            if (urIish.getUser() == null) {
+                String username = preferences.getString("git_username", "");
+                urIish = urIish.setUser(username);
+            }
+            remotePath = urIish.toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid remote git url");
+        }
 
         commitAuthor = preferences.getString("git_commit_author", "");
         commitEmail = preferences.getString("git_commit_email", "");

--- a/mOrgAnd/src/main/res/values/strings_settings.xml
+++ b/mOrgAnd/src/main/res/values/strings_settings.xml
@@ -52,6 +52,7 @@
     <string name="pref_header_git">Git</string>
     <string name="pref_group_remote">Remote</string>
     <string name="pref_title_git_url">Git Url</string>
+    <string name="pref_title_git_branch">Git branch</string>
     <string name="pref_title_git_commit_author">Git commit author</string>
     <string name="pref_title_git_commit_email">Git commit email</string>
     <string name="pref_title_git_keyfile">Private ssh key file</string>

--- a/mOrgAnd/src/main/res/xml/pref_git.xml
+++ b/mOrgAnd/src/main/res/xml/pref_git.xml
@@ -50,6 +50,16 @@
     <PreferenceCategory android:title="@string/preference_advanced">
 
         <EditTextPreference
+            android:key="git_branch"
+            android:title="@string/pref_title_git_branch"
+            android:defaultValue="master"
+            android:selectAllOnFocus="true"
+            android:inputType="text"
+            android:capitalize="words"
+            android:singleLine="true"
+            android:maxLines="1"/>
+
+        <EditTextPreference
             android:key="git_commit_author"
             android:title="@string/pref_title_git_commit_author"
             android:defaultValue=""


### PR DESCRIPTION
JGit was attempting SSH login as root, ignoring what I specified in the username field. From what I've gathered, the SshSessionFactory is used only if the URL contains a username. I added support for handling that issue as well as URL syntax validation.

References:
https://jira.atlassian.com/browse/BAM-7665
