### PR TITLE
Headlines must have a space after the stars

### DIFF
--- a/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/parser/OrgFileParser.java
+++ b/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/parser/OrgFileParser.java
@@ -108,7 +108,7 @@ public class OrgFileParser {
     }
 
     public static OrgNode.Type determineType(final String line) {
-        if (line.startsWith("*"))
+        if (line.matches("[*]+[ ].*"))
             return OrgNode.Type.Headline;
 
         if (line.startsWith("#+"))


### PR DESCRIPTION
It seems headlines must have a space after the stars.

```
***not ok
*** ok
```

![image](https://cloud.githubusercontent.com/assets/24027/4415735/4cd9927c-4531-11e4-9f90-e69f2deeba3a.png)
