### PR TITLE
Fix crash in the calendar settings menu

### DIFF
--- a/mOrgAnd/src/main/java/com/hdweiss/morgand/settings/SettingsActivity.java
+++ b/mOrgAnd/src/main/java/com/hdweiss/morgand/settings/SettingsActivity.java
@@ -181,10 +181,19 @@ public class SettingsActivity extends PreferenceActivity {
 
         // Trigger the listener immediately with the preference's
         // current value.
-        sBindPreferenceSummaryToValueListener.onPreferenceChange(preference,
-                PreferenceManager
-                        .getDefaultSharedPreferences(preference.getContext())
-                        .getString(preference.getKey(), "")
-        );
+
+        if (preference.getKey().equals("calendar_reminder")) {
+            sBindPreferenceSummaryToValueListener.onPreferenceChange(preference,
+                    PreferenceManager
+                            .getDefaultSharedPreferences(preference.getContext())
+                            .getBoolean(preference.getKey(), false)
+            );
+        } else {
+            sBindPreferenceSummaryToValueListener.onPreferenceChange(preference,
+                    PreferenceManager
+                            .getDefaultSharedPreferences(preference.getContext())
+                            .getString(preference.getKey(), "")
+            );
+        }
     }
 }


### PR DESCRIPTION
To reproduce the crash :
- clear data
- go in the calendar settings menu
- tick the checkboxes "Synchronize with calendar" and "Reminders"
- go back and re-enter the calendar settings menu

It should crash right away.

It happens at https://github.com/hdweiss/mOrgAnd/blob/da895a3166ad0773956eb808577a7523635114da/mOrgAnd/src/main/java/com/hdweiss/morgand/settings/SettingsActivity.java#L187 when trying to use getString() with a boolean.

I'm not sure if it's the right way to fix it. Maybe there's a way to tell if it's a boolean without hardcoding "calendar_reminder".

```
09-29 20:39:12.210    3722-3722/com.hdweiss.morgand.debug E/AndroidRuntime﹕ FATAL EXCEPTION: main
    Process: com.hdweiss.morgand.debug, PID: 3722
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.hdweiss.morgand.debug/com.hdweiss.morgand.settings.SettingsActivity}: java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String
            at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2255)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2317)
            at android.app.ActivityThread.access$800(ActivityThread.java:143)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1258)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5070)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:836)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:631)
     Caused by: java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.String
            at android.app.SharedPreferencesImpl.getString(SharedPreferencesImpl.java:223)
            at com.hdweiss.morgand.settings.SettingsActivity.bindPreferenceSummaryToValue(SettingsActivity.java:195)
            at com.hdweiss.morgand.settings.SettingsActivity.access$000(SettingsActivity.java:17)
            at com.hdweiss.morgand.settings.SettingsActivity$CalendarPreferenceFragment.onCreate(SettingsActivity.java:105)
            at android.app.Fragment.performCreate(Fragment.java:1682)
            at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:859)
            at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1063)
            at android.app.BackStackRecord.run(BackStackRecord.java:684)
            at android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1448)
            at android.app.Activity.performStart(Activity.java:5735)
            at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2218)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2317)
            at android.app.ActivityThread.access$800(ActivityThread.java:143)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1258)
            at android.os.Handler.dispatchMessage(Handler.java:102)
            at android.os.Looper.loop(Looper.java:135)
            at android.app.ActivityThread.main(ActivityThread.java:5070)
            at java.lang.reflect.Method.invoke(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:372)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:836)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:631)
```
