### PR TITLE
Fix reminders

### DIFF
--- a/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/calendar/CalendarWrapper.java
+++ b/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/calendar/CalendarWrapper.java
@@ -121,7 +121,6 @@ public class CalendarWrapper {
 		alertvalues.put(CalendarContract.CalendarAlerts.EVENT_ID, eventID);
 		alertvalues.put(CalendarContract.CalendarAlerts.BEGIN, beginTime);
 		alertvalues.put(CalendarContract.CalendarAlerts.END, endTime);
-		alertvalues.put(CalendarContract.CalendarAlerts.ALARM_TIME, this.reminderTime);
 		alertvalues.put(CalendarContract.CalendarAlerts.STATE,
 				CalendarContract.CalendarAlerts.STATE_SCHEDULED);
 		alertvalues.put(CalendarContract.CalendarAlerts.MINUTES, this.reminderTime);

--- a/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/calendar/CalendarWrapper.java
+++ b/mOrgAnd/src/main/java/com/hdweiss/morgand/synchronizer/calendar/CalendarWrapper.java
@@ -114,7 +114,7 @@ public class CalendarWrapper {
 		reminderValues.put(CalendarContract.Reminders.EVENT_ID, eventID);
 		reminderValues.put(CalendarContract.Reminders.METHOD,
                 CalendarContract.Reminders.METHOD_ALERT);
-		context.getContentResolver().insert(CalendarContract.CalendarAlerts.CONTENT_URI,
+		context.getContentResolver().insert(CalendarContract.Reminders.CONTENT_URI,
 				reminderValues);
 
 		ContentValues alertvalues = new ContentValues();

--- a/mOrgAnd/src/main/res/values/strings_settings.xml
+++ b/mOrgAnd/src/main/res/values/strings_settings.xml
@@ -84,7 +84,7 @@
     <string name="preference_calendar_reminder_summary">Add reminders for scheduled items to calendar</string>
     <string name="preference_calendar_reminder">Reminders</string>
     <string name="preference_calendar_reminder_interval_summary">Sets the interval when an alarm is triggered</string>
-    <string name="preference_calendar_reminder_interval">Reminder interval</string>
+    <string name="preference_calendar_reminder_interval">Reminder interval (minutes)</string>
     <string name="preference_calendar_show_habits_summary">Shows habits in the calendar</string>
     <string name="preference_calendar_show_habits">Show habits</string>
     <string name="preference_calendar_show_done_summary">Show items with done TODO keywords the calendar</string>


### PR DESCRIPTION
Without 924b724, I have :

```
10-05 17:28:47.283  31408-31408/com.hdweiss.morgand.debug D/SafeAsyncTask﹕ column 'method' is invalid
10-05 17:28:47.293  31408-31408/com.hdweiss.morgand.debug E/SafeAsyncTask﹕ safeDoInBackground() threw exception
    java.lang.IllegalArgumentException: column 'method' is invalid
            at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:167)
            at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:137)
            at android.content.ContentProviderProxy.insert(ContentProviderNative.java:468)
            at android.content.ContentResolver.insert(ContentResolver.java:1190)
            at com.hdweiss.morgand.synchronizer.calendar.CalendarWrapper.addReminder(CalendarWrapper.java:117)
            at com.hdweiss.morgand.synchronizer.calendar.CalendarWrapper.insertEntry(CalendarWrapper.java:102)
            at com.hdweiss.morgand.synchronizer.calendar.SyncCalendarTask.createOrUpdateEntry(SyncCalendarTask.java:98)
            at com.hdweiss.morgand.synchronizer.calendar.SyncCalendarTask.syncFileSchedule(SyncCalendarTask.java:80)
            at com.hdweiss.morgand.synchronizer.calendar.SyncCalendarTask.safeDoInBackground(SyncCalendarTask.java:52)
            at com.hdweiss.morgand.synchronizer.calendar.SyncCalendarTask.safeDoInBackground(SyncCalendarTask.java:22)
            at com.hdweiss.morgand.utils.SafeAsyncTask.doInBackground(SafeAsyncTask.java:56)
            at android.os.AsyncTask$2.call(AsyncTask.java:288)
            at java.util.concurrent.FutureTask.run(FutureTask.java:237)
            at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:231)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
            at java.lang.Thread.run(Thread.java:841)
```

For 434129e, check the commit message.
